### PR TITLE
Move CommandStarted invokation

### DIFF
--- a/Runtime/Core/Executor/ExecutionSequence.cs
+++ b/Runtime/Core/Executor/ExecutionSequence.cs
@@ -63,6 +63,7 @@ namespace Unibrics.Core.Execution
         private void Start(IExecutableCommand next)
         {
             Logger.Log("Execution", $"Starting executing {next}");
+            CommandStarted?.Invoke(next);
             next.Execute(OnComplete);
         }
 
@@ -92,7 +93,6 @@ namespace Unibrics.Core.Execution
             var next = current = queue[0]();
             queue.RemoveAt(0);
             Start(next);
-            CommandStarted?.Invoke(next);
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "unibrics.core",
   "displayName": "Unibrics Core",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "unity": "2021.1",
   "description": "Core Unibrics package.",
   "dependencies": {


### PR DESCRIPTION
Інвокація івенту `CommandStarted` відбувається в зворотньому напрямку відносно реального порядку виконання команд.

![image](https://github.com/user-attachments/assets/203210d5-885c-423f-b852-32101beb660b)
зеленим -- правильний порядок (внутрішній лог `Logger.Log("Execution", $"Starting executing {next}");`)
червоним -- неправильний порядок (зовнішній лог підписаний на `CommandStarted`)